### PR TITLE
Sub directory support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,9 +333,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -536,9 +536,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -898,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
@@ -980,6 +980,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "url",
  "windows-sys",
 ]
 
@@ -1586,9 +1587,9 @@ checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,7 +962,7 @@ checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
 
 [[package]]
 name = "pocket-relay-plugin"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "blaze-ssl-async",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pocket-relay-plugin"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 description = "ASI plugin for ME3 to allow playing on Pocket Relay servers"
 repository = "https://github.com/PocketRelay/PocketRelayHooks"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ futures-util = { version = "0.3", features = ["sink"] }
 thiserror = "1"
 semver = { version = "1.0", features = ["serde"] }
 hyper = { version = "0.14", features = ["server", "http1", "tcp", "runtime"] }
+url = "2.4.1"
 
 [dependencies.windows-sys]
 version = "0.48"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use hyper::{
     header::{ACCEPT, USER_AGENT},
     StatusCode,
@@ -7,6 +9,7 @@ use reqwest::Client;
 use semver::Version;
 use serde::Deserialize;
 use thiserror::Error;
+use url::Url;
 
 use crate::constants::{APP_VERSION, MIN_SERVER_VERSION, SERVER_IDENT};
 
@@ -26,21 +29,18 @@ struct ServerDetails {
 /// version obtained from the server
 #[derive(Debug, Clone)]
 pub struct LookupData {
-    pub scheme: String,
-    /// The host address of the server
-    pub host: String,
+    /// The server url
+    pub url: Url,
     /// The server version
     pub version: Version,
-    /// The server port
-    pub port: u16,
 }
 
 /// Errors that can occur while looking up a server
 #[derive(Debug, Error)]
 pub enum LookupError {
-    /// The server url was missing the host portion
-    #[error("Unable to find host portion of provided Connection URL")]
-    InvalidHostTarget,
+    /// The server url was invalid
+    #[error("Invalid Connection URL: {0}")]
+    InvalidHostTarget(#[from] url::ParseError),
     /// The server connection failed
     #[error("Failed to connect to server: {0}")]
     ConnectionFailed(reqwest::Error),
@@ -65,26 +65,32 @@ pub enum LookupError {
 ///
 /// `host` The host to try and lookup
 pub async fn try_lookup_host(host: &str) -> Result<LookupData, LookupError> {
-    let mut url = String::new();
+    let url = {
+        let mut url = String::new();
 
-    // Fill in missing host portion
-    if !host.starts_with("http://") && !host.starts_with("https://") {
-        url.push_str("http://");
-        url.push_str(host)
-    } else {
-        url.push_str(host);
-    }
+        // Fill in missing scheme portion
+        if !host.starts_with("http://") && !host.starts_with("https://") {
+            url.push_str("http://");
+            url.push_str(host)
+        } else {
+            url.push_str(host);
+        }
 
-    if !host.ends_with('/') {
-        url.push('/')
-    }
+        // Ensure theres a trailing slash (URL path will be interpeted incorrectly without)
+        if !host.ends_with('/') {
+            url.push('/');
+        }
 
-    url.push_str("api/server");
+        url
+    };
+
+    let url = Url::from_str(&url)?;
+    let info_url = url.join("api/server").expect("Failed to server info URL");
 
     let client = Client::new();
 
     let response = client
-        .get(url)
+        .get(info_url)
         .header(ACCEPT, "application/json")
         .header(USER_AGENT, format!("PocketRelayClient/v{}", APP_VERSION))
         .send()
@@ -112,15 +118,6 @@ pub async fn try_lookup_host(host: &str) -> Result<LookupData, LookupError> {
         }
     };
 
-    let url = response.url();
-    let scheme = url.scheme().to_string();
-
-    let port = url.port_or_known_default().unwrap_or(80);
-    let host = match url.host() {
-        Some(value) => value.to_string(),
-        None => return Err(LookupError::InvalidHostTarget),
-    };
-
     let details = response
         .json::<ServerDetails>()
         .await
@@ -139,9 +136,7 @@ pub async fn try_lookup_host(host: &str) -> Result<LookupData, LookupError> {
     }
 
     Ok(LookupData {
-        scheme,
-        host,
-        port,
+        url,
         version: details.version,
     })
 }

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -135,12 +135,16 @@ pub fn init(runtime: tokio::runtime::Handle, config: Option<ClientConfig>) {
 
                         debug!(
                             "Connected to server {} {} version v{}",
-                            value.scheme, value.host, value.version
+                            value.url.scheme(),
+                            value.url.authority(),
+                            value.version
                         );
 
                         let message = format!(
                             "Connected: {} {} version v{}",
-                            value.scheme, value.host, value.version
+                            value.url.scheme(),
+                            value.url.authority(),
+                            value.version
                         );
 
                         c_label.set_text(&message);

--- a/src/servers/telemetry.rs
+++ b/src/servers/telemetry.rs
@@ -12,7 +12,7 @@ use tokio::{
 use super::spawn_task;
 
 /// Server API endpoint to send telemetry data to
-const TELEMETRY_ENDPOINT: &str = "/api/server/telemetry";
+const TELEMETRY_ENDPOINT: &str = "api/server/telemetry";
 
 pub async fn start_server(target: Arc<LookupData>) {
     // Initializing the underlying TCP listener
@@ -39,10 +39,11 @@ pub async fn start_server(target: Arc<LookupData>) {
 
         spawn_task(async move {
             // Create the telemetry URL
-            let url = format!(
-                "{}://{}:{}{}",
-                target.scheme, target.host, target.port, TELEMETRY_ENDPOINT
-            );
+
+            let url = target
+                .url
+                .join(TELEMETRY_ENDPOINT)
+                .expect("Failed to create telemetry endpoint");
 
             let client = Client::new();
 
@@ -52,7 +53,7 @@ pub async fn start_server(target: Arc<LookupData>) {
 
                 let message: TelemetryMessage = decode_message(message);
                 // TODO: Batch these telemetry messages and send them to the server
-                let _ = client.post(&url).json(&message).send().await;
+                let _ = client.post(url.clone()).json(&message).send().await;
             }
         })
         .await;


### PR DESCRIPTION
## Description
Added support for servers running on nginx that have a non root url path, an example nginx configuration for that would be something like the following:
![image](https://github.com/PocketRelay/Client/assets/33708767/d8938924-3712-48b9-bd69-52841be1ebdb)
Which can now be used in the client like so:
![image](https://github.com/PocketRelay/Client/assets/33708767/715ba017-4a1b-4e41-9e0f-0cbbd1f880bd)

This also technically adds support for things like sticking authentication in the url:
![image](https://github.com/PocketRelay/Client/assets/33708767/2523e61a-c692-4111-8aa2-cd71ad23506a)

## Changes
- Client supports servers hosted on subdirectories

## Related Issues
- Closes #1 